### PR TITLE
Add objc prefix to AlignedCollectionViewFlowLayout

### DIFF
--- a/AlignedCollectionViewFlowLayout/Classes/AlignedCollectionViewFlowLayout.swift
+++ b/AlignedCollectionViewFlowLayout/Classes/AlignedCollectionViewFlowLayout.swift
@@ -77,6 +77,7 @@ private struct AlignmentAxis<A: Alignment> {
 /// over the horizontal and vertical alignment of the cells.
 /// You can use it to align the cells like words in a left- or right-aligned text
 /// and you can specify how the cells are vertically aligned in their row.
+@objc(WTAlignedCollectionViewFlowLayout)
 open class AlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     
     // MARK: - 🔶 Properties

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+See: https://github.com/wantedly/AlignedCollectionViewFlowLayout/pull/1
+
 # AlignedCollectionViewFlowLayout
 
 [![Version](https://img.shields.io/cocoapods/v/AlignedCollectionViewFlowLayout.svg?style=flat)](http://cocoapods.org/pods/AlignedCollectionViewFlowLayout)


### PR DESCRIPTION
## Why

zendesk/commonui_sdk_ios と mischa-hildebrand/AlignedCollectionViewFlowLayout で同名class の インタフェースが異なっていてコンパイルに失敗する

>/Users/shota/Library/Developer/Xcode/DerivedData/Visit-gtbpccihxarynefnhuerolmkiqsc/Build/Products/Visit Qa Debug-iphonesimulator/XCFrameworkIntermediates/ZendeskCommonUISDK/CommonUISDK.framework/Headers/CommonUISDK-Swift.h:251:1: 'AlignedCollectionViewFlowLayout' has different definitions in different modules; first difference is definition in module 'CommonUISDK.Swift' found return type is 'BOOL' (aka '_Bool')

https://github.com/zendesk/commonui_sdk_ios/blob/c7b1eaae04ad234daa72b1235393a23975e4caea/CommonUISDK.xcframework/ios-arm64_i386_x86_64-simulator/CommonUISDK.framework/Headers/CommonUISDK-Swift.h#L959-L966

どうも zendesk/commonui_sdk_ios がコード改変して取り込んでいるっぽい？

## What

`@objc(...)` でclass名の衝突を回避する

mischa-hildebrand/AlignedCollectionViewFlowLayout は悪くない
悪いのは zendesk/commonui_sdk_ios 